### PR TITLE
Fix :human_time_value_label return value

### DIFF
--- a/lib/active_reporter/serializer/base.rb
+++ b/lib/active_reporter/serializer/base.rb
@@ -70,7 +70,7 @@ module ActiveReporter
       def human_time_value_label(dimension, value)
         case value.bin_edges
         when :min_and_max
-          time_formats.each { |step, format| return value.min.strftime(format) if value.max == value.min.advance(step => 1) } || "#{value.min} to #{value.max}"
+          time_formats.detect { |step, format| return value.min.strftime(format) if value.max == value.min.advance(step => 1) } || "#{value.min} to #{value.max}"
         when :min
           "after #{value.min}"
         when :max


### PR DESCRIPTION
When an aggregator of type Time and the steps between them are not consecutive the current implementation returns 'time_formats' content instead of a string describing the interval between the edges of the time period.